### PR TITLE
Remove "bundler/setup" require

### DIFF
--- a/bin/whatsnew
+++ b/bin/whatsnew
@@ -2,7 +2,6 @@
 
 Signal.trap("INT") { abort }
 
-require "bundler/setup"
 require "whatsnew"
 
 if news = Whatsnew.about(Dir.pwd)


### PR DESCRIPTION
Fix this bug:

```
$ whatsnew

/Users/Juan/.gem/ruby/2.2.2/gems/whatsnew-0.4.0/bin/whatsnew:6:in `require': cannot load such file -- whatsnew (LoadError)
	from /Users/Juan/.gem/ruby/2.2.2/gems/whatsnew-0.4.0/bin/whatsnew:6:in `<top (required)>'
	from /Users/Juan/.gem/ruby/2.2.2/bin/whatsnew:23:in `load'
	from /Users/Juan/.gem/ruby/2.2.2/bin/whatsnew:23:in `<main>'
```