### PR TITLE
Add http protocols to matching regexp

### DIFF
--- a/lib/whatsnew/local_files.rb
+++ b/lib/whatsnew/local_files.rb
@@ -36,7 +36,7 @@ module Whatsnew
       def matched_from_git_config
         @matched ||= Dir.chdir(Pathname(path).to_path) do
           `git config --get remote.origin.url`.match(
-            %r{git.+(?<host>(github.com|bitbucket.com|bitbucket.org))[:/](?<owner>\S+)/(?<repo>\S+)\.git}
+            %r{(http://|https://|git.+)(?<host>(github.com|bitbucket.com|bitbucket.org))[:/](?<owner>\S+)/(?<repo>\S+)\.git}
           )
         end
       end


### PR DESCRIPTION
Before this PR, can only match:

```
git@github.com:JuanitoFatas/foo.git
git://github.com:JuanitoFatas/foo.git
```

After this PR, can match following:

```
git@github.com:JuanitoFatas/foo.git
git://github.com:JuanitoFatas/foo.git
+ http://github.com:JuanitoFatas/foo.git
+ https://github.com:JuanitoFatas/foo.git
```